### PR TITLE
Video player will flex properly.

### DIFF
--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -1067,7 +1067,14 @@ export default class VideoPlayer extends Component {
                 onPress={ this.events.onScreenPress }
                 style={[ styles.player.container, this.styles.containerStyle ]}
             >
-                <View style={[ styles.player.container, this.styles.containerStyle ]}>
+
+                {
+                    // Since, We've removed the flex:1 from the player.container, 
+                    // the container of the Video component lost its ability to fill the View 
+                    // and the flex shouldn't inside of container too. 
+                    // Now Parent component can fill the View just perfectly 
+                }
+                <View style={[ styles.player.container, this.styles.containerStyle, styles.player.containerFlex ]}>
                     <Video
                         ref={ videoPlayer => this.player.ref = videoPlayer }
 
@@ -1108,6 +1115,9 @@ export default class VideoPlayer extends Component {
  */
 const styles = {
     player: StyleSheet.create({
+        containerFlex:{
+            flex:1,
+        },
         container: {
             alignSelf: 'stretch',
             justifyContent: 'space-between',

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -1071,7 +1071,7 @@ export default class VideoPlayer extends Component {
                 {
                     // Since, We've removed the flex:1 from the player.container, 
                     // the container of the Video component lost its ability to fill the View 
-                    // and the flex shouldn't inside of container too. 
+                    // and the flex:1 shouldn't be inside of player.container too. 
                     // Now Parent component can fill the View just perfectly 
                 }
                 <View style={[ styles.player.container, this.styles.containerStyle, styles.player.containerFlex ]}>


### PR DESCRIPTION
As I mentioned before, I had the this issue and I solved it by providing necessary styling directly to the component when I call it. The problem caused because we removed the flex:1 from the player.container. 

> Because of that "The View" that contains the Video component lost it ability to fill the parent container.

 I provided necessary styling to the View container of the Video component to give back its ability to fill the parent component.
P.S: Sorry if my explaining was bad. But It should run correctly this time. Let me know if you find a problem.