### PR TITLE
Added props to hide all of the individual controls.

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,5 +56,11 @@ The `<VideoPlayer>` component can take a number of inputs to customize it as nee
     onBack={ () => {} }              // Function fired when back button is pressed.
     onEnd={ () => {} }               // Fired when the video is complete.
 
+    // disabling individual controls
+    disableFullScreen={ false }      // Used to hide the Fullscreen control.
+    disableSeekbar={ false }         // Used to hide the Seekbar control.
+    disableVolume={ false }          // Used to hide the Volume control.
+    disableBack={ false }            // Used to hide the Back control.
+    disableTimer={ false }           // Used to hide the Timer control
 />
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The `<VideoPlayer>` component can take a number of inputs to customize it as nee
     onEnd={ () => {} }               // Fired when the video is complete.
 
     // disabling individual controls
-    disableFullScreen={ false }      // Used to hide the Fullscreen control.
+    disableFullscreen={ false }      // Used to hide the Fullscreen control.
     disableSeekbar={ false }         // Used to hide the Seekbar control.
     disableVolume={ false }          // Used to hide the Volume control.
     disableBack={ false }            // Used to hide the Back control.

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -817,6 +817,11 @@ export default class VideoPlayer extends Component {
      * Back button control
      */
     renderBack() {
+
+        if (this.props.disableBack === true) {
+            return this.renderControl(<View></View>);            
+        }
+
         return this.renderControl(
             <Image
                 source={ require( './assets/img/back.png' ) }
@@ -831,6 +836,11 @@ export default class VideoPlayer extends Component {
      * Render the volume slider and attach the pan handlers
      */
     renderVolume() {
+
+        if (this.props.disableVolume === true) {
+            return this.renderControl(<View></View>);            
+        }
+
         return (
             <View style={ styles.volume.container }>
                 <View style={[
@@ -858,6 +868,11 @@ export default class VideoPlayer extends Component {
      * Render fullscreen toggle and set icon based on the fullscreen state.
      */
     renderFullscreen() {
+
+        if (this.props.disableFullScreen === true) {
+            return this.renderControl(<View></View>);
+        }
+
         let source = this.state.isFullscreen === true ? require( './assets/img/shrink.png' ) : require( './assets/img/expand.png' );
         return this.renderControl(
             <Image source={ source } />,
@@ -900,6 +915,12 @@ export default class VideoPlayer extends Component {
      * Render the seekbar and attach its handlers
      */
     renderSeekbar() {
+
+        //Check if the seekbar has been disabled before rendering.
+        if (this.props.disableSeekbar === true) {
+            return this.renderControl(<View></View>);
+        }
+
         return (
             <View style={ styles.seekbar.container }>
                 <View
@@ -934,6 +955,11 @@ export default class VideoPlayer extends Component {
      * Render the play/pause button and show the respective icon
      */
     renderPlayPause() {
+
+        if (this.props.disablePlayPause === true) {
+            return this.renderControl(<View></View>);
+        }
+
         let source = this.state.paused === true ? require( './assets/img/play.png' ) : require( './assets/img/pause.png' );
         return this.renderControl(
             <Image source={ source } />,
@@ -946,6 +972,7 @@ export default class VideoPlayer extends Component {
      * Render our title...if supplied.
      */
     renderTitle() {
+
         if ( this.opts.title ) {
             return (
                 <View style={[
@@ -969,6 +996,11 @@ export default class VideoPlayer extends Component {
      * Show our timer.
      */
     renderTimer() {
+
+        if (this.props.disableTimer === true) {
+            return this.renderControl(<View></View>);
+        }
+
         return this.renderControl(
             <Text style={ styles.controls.timerText }>
                 { this.calculateTime() }


### PR DESCRIPTION
I've added props to the component which allow the user to hide individual controls. 

What drove this feature was that I was using the component in a carousel, the carousel displays an array of items (images, **videos**, text, etc), if the user clicks on an item, it turns the slideshow into a fullscreen display. 

In this use-case, having the fullscreen fullscreen control display is a little confusing to the user, as the the component is already being displayed at fullscreen.

Essentially in all of the render methods for the ui controls, e.g. renderTimer(), I check if the prop has been passed, if so I just use your renderControl method, passing in an empty, unstyled < View > element. 

Happy to discuss modifying the approach. 