### PR TITLE
Ability to disable individual control items.

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The `<VideoPlayer>` component can take a number of inputs to customize it as nee
     onError={ () => {} }             // Fired when an error is encountered on load
     onBack={ () => {} }              // Function fired when back button is pressed.
     onEnd={ () => {} }               // Fired when the video is complete.
-
+ 
     // disabling individual controls
     disableFullScreen={ false }      // Used to hide the Fullscreen control.
     disableSeekbar={ false }         // Used to hide the Seekbar control.

--- a/README.md
+++ b/README.md
@@ -56,5 +56,11 @@ The `<VideoPlayer>` component can take a number of inputs to customize it as nee
     onBack={ () => {} }              // Function fired when back button is pressed.
     onEnd={ () => {} }               // Fired when the video is complete.
 
+    // disabling individual controls
+    disableFullScreen={ false }      // Used to hide the Fullscreen control.
+    disableSeekbar={ false }         // Used to hide the Seekbar control.
+    disableVolume={ false }          // Used to hide the Volume control.
+    disableBack={ false }            // Used to hide the Back control.
+    disableTimer={ false }           // Used to hide the Timer control
 />
 ```

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ The `<VideoPlayer>` component can take a number of inputs to customize it as nee
     onEnd={ () => {} }               // Fired when the video is complete.
 
     // disabling individual controls
-    disableFullScreen={ false }      // Used to hide the Fullscreen control.
+    disableFullscreen={ false }      // Used to hide the Fullscreen control.
     disableSeekbar={ false }         // Used to hide the Seekbar control.
     disableVolume={ false }          // Used to hide the Volume control.
     disableBack={ false }            // Used to hide the Back control.

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -789,6 +789,11 @@ export default class VideoPlayer extends Component {
      * view and spaces them out.
      */
     renderTopControls() {
+
+        const backControl = !this.props.disableBack ? this.renderBack() : this.renderNullControl();
+        const volumeControl = !this.props.disableVolume ? this.renderVolume() : this.renderNullControl();
+        const fullscreenControl = !this.props.disableFullscreen ? this.renderFullscreen() : this.renderNullControl();
+
         return(
             <Animated.View style={[
                 styles.controls.top,
@@ -802,10 +807,10 @@ export default class VideoPlayer extends Component {
                     style={[ styles.controls.column, styles.controls.vignette,
                 ]}>
                     <View style={ styles.controls.topControlGroup }>
-                        { !this.props.disableBack && this.renderBack() }
+                        { backControl }
                         <View style={ styles.controls.pullRight }>
-                            { !this.props.disableVolume && this.renderVolume() }
-                            { !this.props.disableFullscreen && this.renderFullscreen() }
+                            { volumeControl }
+                            { fullscreenControl }
                         </View>
                     </View>
                 </Image>
@@ -873,6 +878,11 @@ export default class VideoPlayer extends Component {
      * Render bottom control group and wrap it in a holder
      */
     renderBottomControls() {
+
+        const playPauseControl = !this.props.disablePlayPause ? this.renderPlayPause() : this.renderNullControl();
+        const timerControl = !this.props.disableTimer ? this.renderTimer() : this.renderNullControl();
+        const seekbarControl = !this.props.disableSeekbar ? this.renderSeekbar() : this.renderNullControl();
+
         return(
             <Animated.View style={[
                 styles.controls.bottom,
@@ -885,14 +895,14 @@ export default class VideoPlayer extends Component {
                     source={ require( './assets/img/bottom-vignette.png' ) }
                     style={[ styles.controls.column, styles.controls.vignette,
                 ]}>
-                    { !this.props.disableSeekbar && this.renderSeekbar() }
+                    { seekbarControl }
                     <View style={[
                         styles.controls.row,
                         styles.controls.bottomControlGroup
                     ]}>
-                        { !this.props.disablePlayPause && this.renderPlayPause() }
+                        { playPauseControl }
                         { this.renderTitle() }
-                        { !this.props.disableTimer && this.renderTimer() }
+                        { timerControl }
 
                     </View>
                 </Image>
@@ -985,6 +995,14 @@ export default class VideoPlayer extends Component {
             styles.controls.timer
         );
     }
+
+    /**
+     * Renders an empty control, used to disable a control without breaking the view layout.
+     */
+    renderNullControl() {
+        return this.renderControl(<View></View>);   
+    }
+
 
     /**
      * Show loading icon

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -817,6 +817,11 @@ export default class VideoPlayer extends Component {
      * Back button control
      */
     renderBack() {
+
+        if (this.props.disableBack === true) {
+            return this.renderControl(<View></View>);            
+        }
+
         return this.renderControl(
             <Image
                 source={ require( './assets/img/back.png' ) }
@@ -831,6 +836,11 @@ export default class VideoPlayer extends Component {
      * Render the volume slider and attach the pan handlers
      */
     renderVolume() {
+
+        if (this.props.disableVolume === true) {
+            return this.renderControl(<View></View>);            
+        }
+
         return (
             <View style={ styles.volume.container }>
                 <View style={[
@@ -858,6 +868,11 @@ export default class VideoPlayer extends Component {
      * Render fullscreen toggle and set icon based on the fullscreen state.
      */
     renderFullscreen() {
+
+        if (this.props.disableFullScreen === true) {
+            return this.renderControl(<View></View>);
+        }
+
         let source = this.state.isFullscreen === true ? require( './assets/img/shrink.png' ) : require( './assets/img/expand.png' );
         return this.renderControl(
             <Image source={ source } />,
@@ -900,6 +915,12 @@ export default class VideoPlayer extends Component {
      * Render the seekbar and attach its handlers
      */
     renderSeekbar() {
+
+        //Check if the seekbar has been disabled before rendering.
+        if (this.props.disableSeekbar === true) {
+            return this.renderControl(<View></View>);
+        }
+
         return (
             <View style={ styles.seekbar.container }>
                 <View
@@ -934,6 +955,11 @@ export default class VideoPlayer extends Component {
      * Render the play/pause button and show the respective icon
      */
     renderPlayPause() {
+
+        if (this.props.disablePlayPause === true) {
+            return this.renderControl(<View></View>);
+        }
+
         let source = this.state.paused === true ? require( './assets/img/play.png' ) : require( './assets/img/pause.png' );
         return this.renderControl(
             <Image source={ source } />,
@@ -946,6 +972,7 @@ export default class VideoPlayer extends Component {
      * Render our title...if supplied.
      */
     renderTitle() {
+
         if ( this.opts.title ) {
             return (
                 <View style={[
@@ -969,6 +996,11 @@ export default class VideoPlayer extends Component {
      * Show our timer.
      */
     renderTimer() {
+
+        if (this.props.disableTimer === true) {
+            return this.renderControl(<View></View>);
+        }
+
         return this.renderControl(
             <Text style={ styles.controls.timerText }>
                 { this.calculateTime() }


### PR DESCRIPTION
Hey Kyle,

See below for the issue we were talking about last week. 

Sorry for the delayed response, I've been completely swamped with worth this past week (still am!).

I agree that the logic to render a control or not should ideally be outside of the render function. I have just run some tests with the shorthand method you gave as an example, turns out that returning null does effect the flex-box layout, unlike the first approach.

See my test code in the branch '2configurableControls' inside my fork, please forgive the branch names ha ha!!

I've taken both of our approaches in a third branch inside my fork, called... you guessed it '3configurableControls', in this branch I perform the conditional logic for the controls outside of the JSX, storing the result of each conditional in a local variable, which the return statement's JSX references.

See an example snippet below for what i've done in this latest branch

```
/**
 * Renders an empty control, used to disable a control without breaking the view layout.
 */
renderNullControl() {
    return this.renderControl(<View></View>);   
}
```
```

/**
 * Groups the top bar controls together in an animated
 * view and spaces them out.
 */
renderTopControls() {

    const backControl = !this.props.disableBack ? this.renderBack() : this.renderNullControl();
    const volumeControl = !this.props.disableVolume ? this.renderVolume() : this.renderNullControl();
    const fullscreenControl = !this.props.disableFullscreen ? this.renderFullscreen() : this.renderNullControl();

    return(
        <Animated.View style={[
            styles.controls.top,
            {
                opacity: this.animations.topControl.opacity,
                marginTop: this.animations.topControl.marginTop,
            }
        ]}>
            <Image
                source={ require( './assets/img/top-vignette.png' ) }
                style={[ styles.controls.column, styles.controls.vignette,
            ]}>
                <View style={ styles.controls.topControlGroup }>
                    { backControl }
                    <View style={ styles.controls.pullRight }>
                        { volumeControl }
                        { fullscreenControl }
                    </View>
                </View>
            </Image>
        </Animated.View>
    );
}

```
This keeps the separation of concerns between the render top/bottom methods and the render *individual control methods, it also does not break the view layout as there is still technically a control in each ones place, just an empty one if a control has been disabled.

Hope that makes sense. Sorry again about the delay in response. Fire away any questions, happy to discuss further if needed.

Lastly, I like the approach you're talking about at the top of your response. I'd be happy to pitch in on making that happen in the future.