### PR TITLE
Small devices slider hard to press

### DIFF
--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -1290,8 +1290,9 @@ const styles = {
             borderRadius: 12,
             position: 'relative',
             top: 8, left: 8,
-            height: 18,
-            width: 18,
+            height: 20,
+            width: 20,
+            padding: 4
         },
     })
 };

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -1289,10 +1289,10 @@ const styles = {
         circle: {
             borderRadius: 12,
             position: 'relative',
-            top: 8, left: 8,
+            top: 6, left: 8,
             height: 14,
             width: 14,
-            padding: 12
+            padding: 8
         },
     })
 };

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -1290,8 +1290,8 @@ const styles = {
             borderRadius: 12,
             position: 'relative',
             top: 8, left: 8,
-            height: 12,
-            width: 12,
+            height: 18,
+            width: 18,
         },
     })
 };

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -1290,9 +1290,9 @@ const styles = {
             borderRadius: 12,
             position: 'relative',
             top: 8, left: 8,
-            height: 20,
-            width: 20,
-            padding: 4
+            height: 14,
+            width: 14,
+            padding: 12
         },
     })
 };


### PR DESCRIPTION
As I was using this VideoPlayer I found that on small devices the circle for the slider was too small to the point where it was hard to use. I just modified it to add some padding and make it a bit bigger, seems to be working better this way.