### PR TITLE
Hide the controls on first render and fix autoplaying not working on IOS after a re-render

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ The `<VideoPlayer>` component can take a number of inputs to customize it as nee
 
     // settings
     controlTimeout={ 15000 }         // hide controls after ms of inactivity.
+    showOnStart={ true }             // show or hide the controls on first render
     navigator={ navigator }          // prop from React Native <Navigator> component
     seekColor={ '#FFF' }             // fill/handle colour of the seekbar
     videoStyle={ {} }                // Style appended to <Video> component

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -19,7 +19,16 @@ import _ from 'lodash';
 export default class VideoPlayer extends Component {
 
     static defaultProps = {
-        showOnStart: true
+        showOnStart: true,
+        resizeMode: 'contain',
+        playWhenInactive: false,
+        playInBackground: false,
+        title: '',
+        repeat: false,
+        paused: false,
+        muted: false,
+        volume: 1,
+        rate: 1,
     };
 
     constructor( props ) {
@@ -31,11 +40,11 @@ export default class VideoPlayer extends Component {
          */
         this.state = {
             // Video
-            resizeMode: this.props.resizeMode || 'contain',
-            paused: this.props.paused || false,
-            muted: this.props.muted || false,
-            volume: this.props.volume || 1,
-            rate: this.props.rate || 1,
+            resizeMode: this.props.resizeMode,
+            paused: this.props.paused,
+            muted: this.props.muted,
+            volume: this.props.volume,
+            rate: this.props.rate,
             // Controls
 
             isFullscreen: this.props.resizeMode === 'cover' || false,
@@ -60,10 +69,10 @@ export default class VideoPlayer extends Component {
          * Any options that can be set at init.
          */
         this.opts = {
-            playWhenInactive: this.props.playWhenInactive || false,
-            playInBackground: this.props.playInBackground || false,
-            repeat: this.props.repeat || false,
-            title: this.props.title || '',
+            playWhenInactive: this.props.playWhenInactive,
+            playInBackground: this.props.playInBackground,
+            repeat: this.props.repeat,
+            title: this.props.title,
         };
 
         /**

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -44,7 +44,7 @@ export default class VideoPlayer extends Component {
             lastScreenPress: 0,
             volumeFillWidth: 0,
             seekerFillWidth: 0,
-            showControls: true,
+            showControls: this.props.showOnStart,
             volumePosition: 0,
             seekerPosition: 0,
             volumeOffset: 0,

--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -18,6 +18,10 @@ import _ from 'lodash';
 
 export default class VideoPlayer extends Component {
 
+    static defaultProps = {
+        showOnStart: true
+    };
+
     constructor( props ) {
         super( props );
 
@@ -102,14 +106,16 @@ export default class VideoPlayer extends Component {
         /**
          * Various animations
          */
+        const initialValue = this.props.showOnStart ? 1 : 0;
+
         this.animations = {
             bottomControl: {
                 marginBottom: new Animated.Value( 0 ),
-                opacity: new Animated.Value( 1 ),
+                opacity: new Animated.Value( initialValue ),
             },
             topControl: {
                 marginTop: new Animated.Value( 0 ),
-                opacity: new Animated.Value( 1 ),
+                opacity: new Animated.Value( initialValue ),
             },
             video: {
                 opacity: new Animated.Value( 1 ),


### PR DESCRIPTION
This PR adds the ability to hide all the video controls on first render.