### PR TITLE
 fix hide error notification

### DIFF
--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -189,6 +189,9 @@ export default class VideoPlayer extends Component {
 
         state.duration = data.duration;
         state.loading = false;
+        if (state.error === true) {
+            state.error = false
+        }
         this.setState( state );
 
         if ( state.showControls ) {


### PR DESCRIPTION
 fix hide error when the media is loaded and ready to play.
issue: https://github.com/itsnubix/react-native-video-controls/issues/105

After fixing this problem, if you receive a new video url, the error message will be hidden.
Please look at the gif.
![err](https://user-images.githubusercontent.com/12009276/43989504-5a2f3526-9d75-11e8-9d4a-421e02f5b2f2.gif)


