### PR TITLE
Allow flexibility to overwrite default `toggleFullscreen` method

### DIFF
--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -97,7 +97,7 @@ export default class VideoPlayer extends Component {
          * Functions used throughout the application
          */
         this.methods = {
-            toggleFullscreen: this._toggleFullscreen.bind( this ),
+            toggleFullscreen: this.props.onToggleFullscreen || this._toggleFullscreen.bind( this ),
             togglePlayPause: this._togglePlayPause.bind( this ),
             toggleControls: this._toggleControls.bind( this ),
             toggleTimer: this._toggleTimer.bind( this ),


### PR DESCRIPTION
This allows us to write custom logic for `toggleFullscreen` method which didn't worked on Android