### PR TITLE
fix top buttons not clickable while video is loading

### DIFF
--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -1133,8 +1133,8 @@ export default class VideoPlayer extends Component {
                         source={ this.props.source }
                     />
                     { this.renderError() }
-                    { this.renderTopControls() }
                     { this.renderLoader() }
+                    { this.renderTopControls() }
                     { this.renderBottomControls() }
                 </View>
             </TouchableWithoutFeedback>


### PR DESCRIPTION
There's a bug with top buttons with current version, that is, when video loading view is shown, top buttons like back button is not pressable.
I debugged the cause of the issue and found that it's because loading view is rendered over top buttons covering the entire screen with absolute position.
So i fixed it by switching those two lines as follows:

Before:
```
{ this.renderTopControls() }
{ this.renderLoader() }
```

After:
```
{ this.renderLoader() }
{ this.renderTopControls() }
```
