### PR TITLE
Update isFullscreen state from props

### DIFF
--- a/VideoPlayer.js
+++ b/VideoPlayer.js
@@ -158,6 +158,15 @@ export default class VideoPlayer extends Component {
     };
   }
 
+  componentDidUpdate = (prevProps) => {
+    const {isFullscreen} = this.props;
+
+    if (prevProps.isFullscreen !== isFullscreen) {
+      this.setState({
+        isFullscreen,
+      });
+    }
+  };
   /**
     | -------------------------------------------------------
     | Events
@@ -1063,7 +1072,7 @@ export default class VideoPlayer extends Component {
         {...this.player.seekPanResponder.panHandlers}>
         <View
           style={styles.seekbar.track}
-          onLayout={event =>
+          onLayout={(event) =>
             (this.player.seekerWidth = event.nativeEvent.layout.width)
           }
           pointerEvents={'none'}>
@@ -1193,7 +1202,7 @@ export default class VideoPlayer extends Component {
         <View style={[styles.player.container, this.styles.containerStyle]}>
           <Video
             {...this.props}
-            ref={videoPlayer => (this.player.ref = videoPlayer)}
+            ref={(videoPlayer) => (this.player.ref = videoPlayer)}
             resizeMode={this.state.resizeMode}
             volume={this.state.volume}
             paused={this.state.paused}


### PR DESCRIPTION
This is from an earlier rejected PR by VincentCATILLON that was never re-submitted with just the `isFullscreen` logic.
https://github.com/itsnubix/react-native-video-controls/pull/129